### PR TITLE
Exposing full stack trace of error thrown

### DIFF
--- a/commands/mobilehub/import.js
+++ b/commands/mobilehub/import.js
@@ -6,7 +6,7 @@ module.exports = {
     try {
       await context.importProject(context);
     } catch (e) {
-      context.print.error(`An error occured trying to run the command ${e.message}`);
+      context.print.error(`An error occured trying to run the command ${e}`);
     }
   },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-mobilehub-migrator",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A plugin for the AWS Amplify CLI that supports migrating Mobile Hub project resources to be used with the Amplify CLI",
   "author": "Amazon Web Services",
   "license": "Apache-2.0",


### PR DESCRIPTION
*Issue https://github.com/awslabs/amplify-mobilehub-migrator/issues/7*

*Description of changes:*
This will reveal more details about errors thrown while running the `mobilehub import` command

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
