### PR TITLE
Check for analytics before adding to meta file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 package-lock.json
-package-lock.json

--- a/extensions/import-project.js
+++ b/extensions/import-project.js
@@ -50,7 +50,7 @@ module.exports = (context) => {
       context.updateRegion(frontendHandlerModule);
       spinner.succeed('Your Mobile Hub project was successfully imported.');
     } catch (error) {
-      spinner.fail(`There was an error importing your Mobile Hub project: ${error.message}`);
+      spinner.fail(`There was an error importing your Mobile Hub project: ${error}`);
       throw error;
     }
   };
@@ -132,17 +132,20 @@ function createAuth(featureResult, config) {
 }
 
 async function createAnalytics(featureResult, config, context) {
-  config.analytics = {};
-  config.analytics[`analytics${new Date().getMilliseconds()}`] = {
-    service: 'Pinpoint',
-    lastPushTimeStamp: new Date().toISOString(),
-    output: {
-      appName: featureResult.find(item => item.type === 'AWS::Pinpoint::AnalyticsApplication').name,
-      Region: featureResult.region,
-      Id: featureResult.find(item => item.type === 'AWS::Pinpoint::AnalyticsApplication').arn,
-    },
-  };
-  config = await createNotifications(featureResult, config, context);
+  const hasAnalytics = featureResult.find(item => item.type === 'AWS::Pinpoint::AnalyticsApplication');
+  if (hasAnalytics) {
+    config.analytics = {};
+    config.analytics[`analytics${new Date().getMilliseconds()}`] = {
+      service: 'Pinpoint',
+      lastPushTimeStamp: new Date().toISOString(),
+      output: {
+        appName: featureResult.find(item => item.type === 'AWS::Pinpoint::AnalyticsApplication').name,
+        Region: featureResult.region,
+        Id: featureResult.find(item => item.type === 'AWS::Pinpoint::AnalyticsApplication').arn,
+      },
+    };
+    config = await createNotifications(featureResult, config, context);
+  }
   return config;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-mobilehub-migrator",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A plugin for the AWS Amplify CLI that supports migrating Mobile Hub project resources to be used with the Amplify CLI",
   "author": "Amazon Web Services",
   "license": "Apache-2.0",


### PR DESCRIPTION
*Issue #7:* Fixes issue where an error is thrown during import

*Description of changes:* 
Analytics is not added as a default to all mobile hub projects. This change checks for analytics before trying to parse project details.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
